### PR TITLE
Fix write error on missing object

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -78,7 +78,8 @@ for message in sortedMessages:
         lastParsedDate = message.date
         print(str(response.status_code) + u": " + response.text)
 
-if lastParsedDate:
-    lastItemFile.write(str(time.mktime(lastParsedDate.utctimetuple())))
+if lastItemFile:
+    if lastParsedDate:
+        lastItemFile.write(str(time.mktime(lastParsedDate.utctimetuple())))
 
-lastItemFile.close()
+    lastItemFile.close()


### PR DESCRIPTION
If `PARSE_ONLY_NEW` is false, the `lastItemFile` is not created as file, so it produces a error executing the last lines. This fix should skip that condition for avoid this error:

	Traceback (most recent call last):
	  File "parser.py", line 84, in <module>
		lastItemFile.write(str(time.mktime(lastParsedDate.utctimetuple())))
	AttributeError: 'NoneType' object has no attribute 'write'